### PR TITLE
Allow newrelic access to log files and network on centos 6

### DIFF
--- a/newrelic.te
+++ b/newrelic.te
@@ -1,8 +1,10 @@
 
-module newrelic 1.0;
+module newrelic 1.1;
 
 require {
 	type httpd_t;
+	type sysctl_net_t;
+	type var_log_t;
 	type tmp_t;
 	type initrc_var_run_t;
 	type initrc_tmp_t;
@@ -10,6 +12,7 @@ require {
 	class sock_file write;
 	class unix_stream_socket connectto;
 	class file { read write open };
+	class dir { read search };
 }
 
 #============= httpd_t ==============
@@ -20,3 +23,7 @@ allow httpd_t initrc_tmp_t:file open;
 allow httpd_t initrc_var_run_t:file { read write };
 
 allow httpd_t tmp_t:sock_file write;
+
+allow httpd_t sysctl_net_t:dir { read search };
+allow httpd_t sysctl_net_t:file { read };
+allow httpd_t var_log_t:file open;


### PR DESCRIPTION
Fixes issue where newrelic could not write to log files, nor to net by adding the required allow declarations according to audit2allow.